### PR TITLE
Fixed Issues with vote-service.yaml and result-service.yaml in k8s-specifications/

### DIFF
--- a/k8s-specifications/networkpolicy.yaml
+++ b/k8s-specifications/networkpolicy.yaml
@@ -1,3 +1,4 @@
+apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: access-redis

--- a/k8s-specifications/result-service.yaml
+++ b/k8s-specifications/result-service.yaml
@@ -12,4 +12,4 @@ spec:
     targetPort: 80
     nodePort: 31001
   selector:
-    app: results
+    app: result

--- a/k8s-specifications/vote-service.yaml
+++ b/k8s-specifications/vote-service.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: "vote-service"
     port: 5000
-    targetPort: 8080
+    targetPort: 80
     nodePort: 31000
   selector:
     app: vote


### PR DESCRIPTION
Update Kubernetes manifests:

1. Vote-Service: Changed port from 8080 to 80 to match application port.
2. Result-Service (Selector): Fixed typo from "results" to "result" for correct pod targeting.
3. NetworkPolicy: Added missing apiVersion for proper resource definition.

These changes address port mismatch, incorrect selector, and incomplete NetworkPolicy definition.